### PR TITLE
feature/mx-1359 Skip integration tests by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ linter:
 pytest:
 	# run the pytest test suite
 	@ echo running tests; \
-	poetry run pytest; \
+	poetry run pytest -m "not integration"; \
 
 build:
 	# build the python package


### PR DESCRIPTION
- for mx-1359 `mex.common.testing.plugin` must stop skipping integration tests in CI automatically
- as a preparation for that, this pr will set the makefile up to skip integration tests by default