### PR TITLE
Bump cookiecutter template to 39db8b

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "71137ce60c22f449d66138dcd113772acd678a39",
+  "commit": "39db8b85e6bbde62ab72318329d9410f14187dab",
   "context": {
     "cookiecutter": {
       "project_name": "drop",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.4.9
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:c237868640926c0c009f13f77d57606370fb9c1ea788810b599d7af5cda1d02d"
+content_hash = "sha256:7d9bf89df1ab5b9a17dfcca683540c97481a0889235c31cb920a19e4a27d4be1"
 
 [[package]]
 name = "alabaster"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ optional-dependencies.dev = [
     "pytest-random-order==1.1.1",
     "pytest-xdist==3.6.1",
     "pytest==8.2.2",
-    "ruff==0.4.8",
+    "ruff==0.4.9",
     "sphinx==7.3.7",
 ]
 
@@ -47,7 +47,7 @@ distribution = true
 [tool.pdm.scripts]
 update-all = { cmd = "pdm update --group :all --update-all --save-compatible" }
 lock-all = { cmd = "pdm lock --group :all --refresh" }
-install-all = { cmd = "pdm install --group :all --no-editable --no-lock" }
+install-all = { cmd = "pdm install --group :all --frozen-lockfile" }
 export-all = { cmd = "pdm export --group :all --no-hashes -f requirements" }
 apidoc = { cmd = "pdm run sphinx-apidoc -f -o docs/source mex" }
 sphinx = { cmd = "pdm run sphinx-build -aE -b dirhtml docs docs/dist" }


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/39db8b
