### PR TITLE
Bump cookiecutter template to 77775e

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "cee205846b2eb6f25e1ce762f395aa50ccbbf93e",
+  "commit": "77775ea327e6f007032671870326cde13a3167bd",
   "context": {
     "cookiecutter": {
       "project_name": "drop",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           --tag ghcr.io/robert-koch-institut/mex-drop:latest \
           --tag ghcr.io/robert-koch-institut/mex-drop:${{ github.sha }} \
           --tag ghcr.io/robert-koch-institut/mex-drop:${{ needs.release.outputs.tag }}
-          docker push ghcr.io/robert-koch-institut/mex-drop:latest
+          docker push --all-tags ghcr.io/robert-koch-institut/mex-drop:latest
 
   distribute:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/77775e
