### PR TITLE
Bump cookiecutter template to bae864

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "77775ea327e6f007032671870326cde13a3167bd",
+  "commit": "bae86448088992cdbd3acde751ad7aa19a79d71b",
   "context": {
     "cookiecutter": {
       "project_name": "drop",


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/bae864
