### PR TITLE
Bump cookiecutter template to b0a205

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "af56c8fa17144906e94518391acc9795d5f2dc89",
+  "commit": "b0a2056a104f39cd18e6b395a27d18473caa73d7",
   "context": {
     "cookiecutter": {
       "project_name": "drop",


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/b0a205

# Conflicts

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -59,6 +59,8 @@ jobs:
 
       - name: Configure git
         env:
+          MEX_BOT_EMAIL: ${{ vars.MEX_BOT_EMAIL }}
+          MEX_BOT_USER: ${{ vars.MEX_BOT_USER }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PUB: ${{ secrets.SIGNING_PUB }}
         run: |
```

```diff a/.github/workflows/cookiecutter.yml b/.github/workflows/cookiecutter.yml	(rejected hunks)
@@ -48,6 +48,8 @@ jobs:
 
       - name: Configure git
         env:
+          MEX_BOT_EMAIL: ${{ vars.MEX_BOT_EMAIL }}
+          MEX_BOT_USER: ${{ vars.MEX_BOT_USER }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PUB: ${{ secrets.SIGNING_PUB }}
         run: |
```
