### PR TITLE
Bump cookiecutter template to 08b84c

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "716a581e36bd544e0b34a7f92078435de557fa76",
+  "commit": "08b84c365a20d24ca04369a70495034491e0a401",
   "context": {
     "cookiecutter": {
       "project_name": "drop",
       "short_summary": "Data upload and download service for the MEx project.",
       "long_summary": "The `mex-drop` package provides an API for uploading data to and downloading data from the MEx project. Request payloads need to be JSON-formatted but can have arbitrary structures. Accepted data will be ingested and processed asynchronously.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "716a581e36bd544e0b34a7f92078435de557fa76"
+      "_commit": "08b84c365a20d24ca04369a70495034491e0a401"
     }
   },
   "directory": null,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.11.7
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.22.4
+    rev: 2.24.1
     hooks:
       - id: pdm-lock-check
         name: pdm


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/08b84c

# Conflicts

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v41.0.14
+        uses: renovatebot/github-action@v41.0.21
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-drop"
```

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -138,5 +138,5 @@ known-first-party = ["mex", "tests"]
 convention = "google"
 
 [build-system]
-requires = ["pdm-backend==2.4.3"]
+requires = ["pdm-backend==2.4.4"]
 build-backend = "pdm.backend"
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,4 +1,4 @@
 cruft==2.16.0
-mex-release==0.3.0
-pdm==2.22.4
-pre-commit==4.1.0
+mex-release==0.3.2
+pdm==2.24.0
+pre-commit==4.2.0
```
