### PR TITLE
Bump cookiecutter template to 7de6ba

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159",
+  "commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5",
   "context": {
     "cookiecutter": {
       "project_name": "drop",
       "short_summary": "Data upload and download service for the MEx project.",
       "long_summary": "The `mex-drop` package provides an API for uploading data to and downloading data from the MEx project. Request payloads need to be JSON-formatted but can have arbitrary structures. Accepted data will be ingested and processed asynchronously.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159"
+      "_commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5"
     }
   },
   "directory": null,


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/7de6ba
