### PR TITLE
Bump cookiecutter template to 0eb107

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5",
+  "commit": "0eb10763f9de744b839dca9c86e32c5033d3d77a",
   "context": {
     "cookiecutter": {
       "project_name": "drop",
       "short_summary": "Data upload and download service for the MEx project.",
       "long_summary": "The `mex-drop` package provides an API for uploading data to and downloading data from the MEx project. Request payloads need to be JSON-formatted but can have arbitrary structures. Accepted data will be ingested and processed asynchronously.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5"
+      "_commit": "0eb10763f9de744b839dca9c86e32c5033d3d77a"
     }
   },
   "directory": null,

--- a/.github/workflows/reviewing.yml
+++ b/.github/workflows/reviewing.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Add assignee
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,19 @@
     },
     "packageRules": [
         {
+            "matchPackageNames": [
+                "mex-*"
+            ],
+            "matchUpdateTypes": [
+                "digest",
+                "lockFileMaintenance",
+                "major",
+                "minor",
+                "patch",
+                "pin"
+            ]
+        },
+        {
             "matchUpdateTypes": [
                 "digest",
                 "lockFileMaintenance",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==0.3.3
-pdm==2.24.2
+pdm==2.25.2
 pre-commit==4.2.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/0eb107
