### PR TITLE
Bump cookiecutter template to b18156

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "e886ec4a4cddc865dedb40f9ead24530884110a8",
+  "commit": "b18156bf6f17b41851818ce92ce719a9c2f63a11",
   "context": {
     "cookiecutter": {
       "project_name": "drop",
       "short_summary": "Data upload and download service for the MEx project.",
       "long_summary": "The `mex-drop` package provides an API for uploading data to and downloading data from the MEx project. Request payloads need to be JSON-formatted but can have arbitrary structures. Accepted data will be ingested and processed asynchronously.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "e886ec4a4cddc865dedb40f9ead24530884110a8"
+      "_commit": "b18156bf6f17b41851818ce92ce719a9c2f63a11"
     }
   },
   "directory": null,

--- a/.dockerignore
+++ b/.dockerignore
@@ -123,6 +123,7 @@ dmypy.json
 .cruft.json
 .invenio.private
 .states
+.tmp_dagster_home_*
 .web
 *.ndjson
 assets/external/
@@ -149,7 +150,6 @@ work/
 .bandit
 .isort.cfg
 .mypy.ini
-.pdm-python
 .pre-commit-config.yaml
 .pydocstyle
 Makefile

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -80,7 +80,7 @@ jobs:
             printf '\n# Conflicts\n' >> .cruft-pr-body
           fi
           find . -type f -name "*.rej" | while read -r line ; do
-            printf '\n```' >> .cruft-pr-body
+            printf '\n```diff\n' >> .cruft-pr-body
             cat ${line} >> .cruft-pr-body
             printf '```\n' >> .cruft-pr-body
           done

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Export dependencies
         run: |
           mkdir --parents pdm
-          pdm export-all > pdm/requirements.txt
+          pdm export --group :all --no-hashes -f requirements > pdm/requirements.txt
 
       - name: Run trivy
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -61,4 +61,4 @@ jobs:
         run: make install
 
       - name: Run linters
-        run: make linter
+        run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ dmypy.json
 .aws/
 .invenio.private
 .states
+.tmp_dagster_home_*
 .web
 *.ndjson
 assets/external/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,8 +33,8 @@ repos:
     hooks:
     - id: mypy
       name: mypy
-      entry: pdm mypy-daemon
-      files: ^mex/
+      entry: pdm run dmypy run --timeout 7200 -- mex tests
+      files: ^(mex|tests)/
       language: system
       pass_filenames: false
       types: [python]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-.PHONY: all test setup hooks install linter pytest wheel image run start docs
-all: install test
-test: linter pytest
+.PHONY: all test setup hooks install lint unit test wheel image run start docs
+all: install lint test
 
 LATEST = $(shell git describe --tags $(shell git rev-list --tags --max-count=1))
 PWD = $(shell pwd)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@
 
 ## Supported Versions
 
-This software package is currently in pre-release state. That means changes can
-occur frequently and only the latest released version will be supported with
-security and bug fixes. It is therefore not recommended to use this package in
-productive environments.
+This software package is in active development and designed for internal use.
+Changes to code and architecture can occur frequently and only the latest version will
+be supported with security and bug fixes. If you plan on re-using parts of MEx,
+please refer to the LICENSE for liability clarifications.
 
 ## Reporting a Vulnerability
 

--- a/mex.bat
+++ b/mex.bat
@@ -3,6 +3,8 @@
 set target=%1
 
 if "%target%"=="install" goto install
+if "%target%"=="lint" goto lint
+if "%target%"=="unit" goto unit
 if "%target%"=="test" goto test
 if "%target%"=="docs" goto docs
 echo invalid argument %target%
@@ -27,15 +29,24 @@ pdm install-all
 exit /b %errorlevel%
 
 
-:test
+:lint
 @REM run the linter hooks from pre-commit on all files
 echo linting all files
-pdm lint
-if %errorlevel% neq 0 exit /b %errorlevel%
+pre-commit run --all-files
+exit /b %errorlevel%
 
-@REM run the pytest test suite with unit and integration tests
+
+:unit
+@REM run the test suite with all unit tests
+echo running unit tests
+pdm run pytest -m 'not integration'
+exit /b %errorlevel%
+
+
+:test
+@REM run the unit and integration test suites
 echo running all tests
-pdm test
+pdm run pytest --numprocesses=auto --dist=worksteal
 exit /b %errorlevel%
 
 


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/b18156

# Conflicts

```diff a/Makefile b/Makefile	(rejected hunks)
@@ -21,20 +20,25 @@ install: setup hooks
 	@ echo installing package; \
 	pdm install-all; \
 
-linter:
+lint:
 	# run the linter hooks from pre-commit on all files
 	@ echo linting all files; \
-	pdm lint; \
+	pre-commit run --all-files; \
 
-pytest:
-	# run the pytest test suite with all unit tests
+unit:
+	# run the test suite with all unit tests
 	@ echo running unit tests; \
-	pdm unit; \
+	pdm run pytest -m 'not integration'; \
+
+test:
+	# run the unit and integration test suites
+	@ echo running all tests; \
+	pdm run pytest --numprocesses=auto --dist=worksteal; \
 
 wheel:
 	# build the python package
 	@ echo building wheel; \
-	pdm wheel; \
+	pdm build --no-sdist; \
 
 image:
 	# build the docker image
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,4 +1,4 @@
 cruft==2.16.0
-mex-release==0.3.3
-pdm==2.25.4
-pre-commit==4.2.0
+mex-release==0.3.4
+pdm==2.25.5
+pre-commit==4.3.0
```

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -42,16 +42,11 @@ distribution = true
 update-all = { cmd = "pdm update --group :all --update-all --save-compatible" }
 lock-all = { cmd = "pdm lock --group :all --python='==3.11.*'" }
 install-all = { cmd = "pdm install --group :all --frozen-lockfile" }
-export-all = { cmd = "pdm export --group :all --no-hashes -f requirements" }
 apidoc = { cmd = "pdm run sphinx-apidoc -f -o docs/source mex" }
 sphinx = { cmd = "pdm run sphinx-build -aE -b dirhtml docs docs/dist" }
 doc = { composite = ["apidoc", "sphinx"] }
-wheel = { cmd = "pdm build --no-sdist" }
-mypy-daemon = { cmd = "pdm run dmypy run --timeout 7200 -- mex tests" }
 lint = { cmd = "pre-commit run --all-files" }
-unit = { cmd = "pdm run pytest -m 'not integration'" }
 test = { cmd = "pdm run pytest --numprocesses=auto --dist=worksteal" }
-all = { composite = ["install-all", "lint", "test", "doc"] }
 
 [tool.pydantic-mypy]
 warn_untyped_fields = true
```

```diff a/README.md b/README.md	(rejected hunks)
@@ -61,22 +61,15 @@ components of the MEx project are open-sourced under the same license as well.
 
 ### Installation
 
-- on unix, consider using pyenv https://github.com/pyenv/pyenv
-  - get pyenv `curl https://pyenv.run | bash`
-  - install 3.11 `pyenv install 3.11`
-  - switch version `pyenv global 3.11`
-  - run `make install`
-- on windows, consider using pyenv-win https://pyenv-win.github.io/pyenv-win/
-  - follow https://pyenv-win.github.io/pyenv-win/#quick-start
-  - install 3.11 `pyenv install 3.11`
-  - switch version `pyenv global 3.11`
-  - run `.\mex.bat install`
+- install python3.11 on your system
+- on unix, run `make install`
+- on windows, run `.\mex.bat install`
 
 ### Linting and testing
 
-- run all linters with `pdm lint`
-- run only unit tests with `pdm unit`
-- run unit and integration tests with `pdm test`
+- run all linters with `make lint` or `.\mex.bat lint`
+- run unit and integration tests with `make test` or `.\mex.bat test`
+- run just the unit tests with `make unit` or `.\mex.bat unit`
 
 ### Updating dependencies
 
```

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v43.0.3
+        uses: renovatebot/github-action@v43.0.7
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-drop"
```

```diff a/.github/workflows/testing.yml b/.github/workflows/testing.yml	(rejected hunks)
@@ -61,4 +61,4 @@ jobs:
         run: make install
 
       - name: Run test suite
-        run: make pytest
+        run: make test
```
