### PR TITLE
Bump cookiecutter template to 491e2d

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "0c16a64c09906a7f4dab3297a99d8e358214f566",
+  "commit": "491e2def91056e66b37a02f9bda6177f79b2912e",
   "context": {
     "cookiecutter": {
       "project_name": "drop",
       "short_summary": "Data upload and download service for the MEx project.",
       "long_summary": "The `mex-drop` package provides an API for uploading data to and downloading data from the MEx project. Request payloads need to be JSON-formatted but can have arbitrary structures. Accepted data will be ingested and processed asynchronously.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "0c16a64c09906a7f4dab3297a99d8e358214f566"
+      "_commit": "491e2def91056e66b37a02f9bda6177f79b2912e"
     }
   },
   "directory": null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/491e2d
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/491e2d
