### PR TITLE
Bump cookiecutter template to 172aac

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "491e2def91056e66b37a02f9bda6177f79b2912e",
+  "commit": "172aac4cddf8ce8f9c90d2490af8284d5b994d01",
   "context": {
     "cookiecutter": {
       "project_name": "drop",
       "short_summary": "Data upload and download service for the MEx project.",
       "long_summary": "The `mex-drop` package provides an API for uploading data to and downloading data from the MEx project. Request payloads need to be JSON-formatted but can have arbitrary structures. Accepted data will be ingested and processed asynchronously.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "491e2def91056e66b37a02f9bda6177f79b2912e"
+      "_commit": "172aac4cddf8ce8f9c90d2490af8284d5b994d01"
     }
   },
   "directory": null,

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v46.1.5
+        uses: renovatebot/github-action@v46.1.6
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-drop"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/172aac
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/491e2d
 
 ### Deprecated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "mex-common>=1.17,<1.18",
     "pydantic>=2.12,<3",
     "reflex>=0.8,<9",
-    "starlette>=0.52,<0.53",
+    "starlette>=1,<1.1",
     "typer>=0.24,<0.25",
     "uvicorn>=0.42,<0.43",
 ]

--- a/renovate.json
+++ b/renovate.json
@@ -18,29 +18,28 @@
     },
     "packageRules": [
         {
+            "description": "Apply all updates after cooldown of 7 days, hopefully avoiding malicious updates which are yanked in the meantime",
+            "matchUpdateTypes": [
+                "digest",
+                "lockFileMaintenance",
+                "major",
+                "minor",
+                "patch",
+                "pin"
+            ],
+            "minimumReleaseAge": "7 days",
+            "minimumReleaseAgeBehaviour": "timestamp-optional"
+        },
+        {
+            "description": "Immediately apply updates of mex packages",
             "matchPackageNames": [
                 "mex-*"
             ],
-            "matchUpdateTypes": [
-                "digest",
-                "lockFileMaintenance",
-                "major",
-                "minor",
-                "patch",
-                "pin"
-            ]
-        },
-        {
-            "matchUpdateTypes": [
-                "digest",
-                "lockFileMaintenance",
-                "major",
-                "minor",
-                "patch",
-                "pin"
-            ],
-            "minimumReleaseAge": "7 days"
+            "minimumReleaseAge": "0 days"
         }
     ],
-    "prFooter": ""
+    "prFooter": "",
+    "vulnerabilityAlerts": {
+        "enabled": true
+    }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.0
-uv==0.10.11
+uv==0.10.12
 pre-commit==4.5.1

--- a/uv.lock
+++ b/uv.lock
@@ -797,7 +797,7 @@ requires-dist = [
     { name = "mex-common", specifier = ">=1.17,<1.18" },
     { name = "pydantic", specifier = ">=2.12,<3" },
     { name = "reflex", specifier = ">=0.8,<9" },
-    { name = "starlette", specifier = ">=0.52,<0.53" },
+    { name = "starlette", specifier = ">=1,<1.1" },
     { name = "typer", specifier = ">=0.24,<0.25" },
     { name = "uvicorn", specifier = ">=0.42,<0.43" },
 ]
@@ -1730,14 +1730,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/172aac
