### PR TITLE
Bump cookiecutter template to f624a3

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "dd987e6cc7f1bcb7298b4e7aecd5055de15458bb",
+  "commit": "f624a318299133fc7e5d74a12153d52f32500522",
   "context": {
     "cookiecutter": {
       "project_name": "drop",
       "short_summary": "Data upload and download service for the MEx project.",
       "long_summary": "The `mex-drop` package provides an API for uploading data to and downloading data from the MEx project. Request payloads need to be JSON-formatted but can have arbitrary structures. Accepted data will be ingested and processed asynchronously.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "dd987e6cc7f1bcb7298b4e7aecd5055de15458bb"
+      "_commit": "f624a318299133fc7e5d74a12153d52f32500522"
     }
   },
   "directory": null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/f624a3
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/dd987e
 - update mex-release to 1.3.3
 - update mex-common to 1.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.3
-uv==0.11.8
+uv==0.11.15
 pre-commit==4.6.0


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/f624a3
