### PR TITLE
feature/converge-shared-ui-with-admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - use docker-compose for CI testing
 - run the dev server on ports 8020/8021
 - assert uploaded files via the drop api
+- align `NavItem` with mex-admin: match on `router.route_id` via `route_ids`
+  instead of comparing `router.page.path`, and track `active` instead of `underline`
+- show a toast instead of a native browser alert on failed login
+- add `data-testid` to the login inputs and nav bar links
+- run the playwright test browser at 1600x900, like mex-admin
 
 ### Deprecated
 
 ### Removed
 
 - version hover card on the app logo
+- `html_lang` from the reflex app config
+- background color of the nav bar spacer, leaving the backdrop filter
 
 ### Fixed
 
 - point reflex api and deploy urls at `localhost` instead of `0.0.0.0`
 - fix frontend healthcheck port in `compose.yaml`
 - create the drop directory in the image, so mounted volumes are owned by `mex`
+- focus the x-system input on the login page (`autofocus` was not a reflex prop)
+- register `custom_backend_handler`, so backend errors surface as toasts
+- pass the sitemap plugin class to `disable_plugins`, silencing a reflex 0.9 deprecation
+- set `width: 100%` on the page container, matching mex-admin
 
 ### Security
 

--- a/mex/drop/layout.py
+++ b/mex/drop/layout.py
@@ -39,9 +39,10 @@ def nav_link(item: NavItem) -> rx.Component:
     """Return a link component for the given navigation item."""
     return rx.link(
         rx.text(item.title, size="4", weight="medium"),
-        href=item.path,
-        underline=item.underline,  # type: ignore[arg-type]
-        class_name="nav-item",
+        href=item.raw_path,
+        underline=rx.cond(item.active, "always", "none"),
+        class_name=rx.cond(item.active, "nav-item nav-item-active", "nav-item"),
+        custom_attrs={"data-testid": f"nav-item-{item.route_ids[0]}"},
     )
 
 
@@ -66,7 +67,6 @@ def nav_bar() -> rx.Component:
                 height="var(--space-6)",
                 width="100%",
                 backdropFilter="var(--backdrop-filter-panel)",
-                backgroundColor="var(--card-background-color)",
             ),
         ),
         rx.card(
@@ -136,6 +136,7 @@ def page(*children: rx.Component) -> rx.Component:
                 {
                     "--app-max-width": "calc(1480px * var(--scaling))",
                     "--app-min-width": "calc(800px * var(--scaling))",
+                    "width": "100%",
                 }
             ),
         ),

--- a/mex/drop/login/main.py
+++ b/mex/drop/login/main.py
@@ -9,13 +9,14 @@ def login_x_system() -> rx.Component:
     return rx.vstack(
         rx.text("X-System"),
         rx.input(
-            autofocus=True,
+            auto_focus=True,
             name="x_system",
             on_change=LoginState.set_x_system,
             placeholder="X-System",
             size="3",
             tab_index=1,
             style=rx.Style(width="100%"),
+            custom_attrs={"data-testid": "input-x-system"},
         ),
         style=rx.Style(width="100%"),
     )
@@ -33,6 +34,7 @@ def login_api_key() -> rx.Component:
             tab_index=2,
             type="password",
             style=rx.Style(width="100%"),
+            custom_attrs={"data-testid": "input-api-key"},
         ),
         style=rx.Style(width="100%"),
     )

--- a/mex/drop/login/state.py
+++ b/mex/drop/login/state.py
@@ -32,4 +32,4 @@ class LoginState(State):
             )
             self.reset()  # reset api_key/x_system
             return rx.redirect("/")
-        return rx.window_alert("Invalid credentials.")
+        return rx.toast.error("Invalid credentials.")

--- a/mex/drop/models.py
+++ b/mex/drop/models.py
@@ -11,6 +11,7 @@ class User(BaseModel):
 class NavItem(BaseModel):
     """Model for one navigation bar item."""
 
-    title: str = ""
-    path: str = "/"
-    underline: str = "none"
+    title: str
+    route_ids: list[str]
+    raw_path: str
+    active: bool = False

--- a/mex/drop/state.py
+++ b/mex/drop/state.py
@@ -11,11 +11,13 @@ class State(rx.State):
     nav_items: list[NavItem] = [
         NavItem(
             title="Upload",
-            path="/",
+            route_ids=["/", "/index"],
+            raw_path="/",
         ),
         NavItem(
             title="File History",
-            path="/file-history",
+            route_ids=["/file-history"],
+            raw_path="/file-history",
         ),
     ]
 
@@ -36,7 +38,4 @@ class State(rx.State):
     def load_nav(self) -> None:
         """Event hook for updating the navigation on page loads."""
         for nav_item in self.nav_items:
-            if self.router.page.path == nav_item.path:
-                nav_item.underline = "always"
-            else:
-                nav_item.underline = "none"
+            nav_item.active = self.router.route_id in nav_item.route_ids

--- a/mex/mex.py
+++ b/mex/mex.py
@@ -2,6 +2,7 @@ import reflex as rx
 from reflex.components.radix import themes
 
 from mex.drop.api.main import api as drop_api
+from mex.drop.exceptions import custom_backend_handler
 from mex.drop.file_history.main import index as file_history_index
 from mex.drop.file_history.state import ListState
 from mex.drop.login.main import index as login_index
@@ -10,12 +11,12 @@ from mex.drop.upload.main import index as upload_index
 from mex.drop.utils import load_settings
 
 app = rx.App(
-    html_lang="en",
     theme=themes.theme(accent_color="blue", has_background=False),
     style={
         ">a": {"opacity": "0"},
     },
     api_transformer=drop_api,
+    backend_exception_handler=custom_backend_handler,
 )
 app.add_page(
     upload_index,

--- a/rxconfig.py
+++ b/rxconfig.py
@@ -1,8 +1,9 @@
 import reflex as rx
+from reflex.plugins.sitemap import SitemapPlugin
 
 config = rx.Config(
     app_name="mex",
-    disable_plugins=["reflex.plugins.sitemap.SitemapPlugin"],
+    disable_plugins=[SitemapPlugin],
     frontend_port=8020,
     backend_port=8021,
     telemetry_enabled=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -26,6 +27,20 @@ TEST_USER_DATABASE = UserDatabase(
         APIKey("i-do-what-i-want"): ["admin"],
     }
 )
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(
+    browser_context_args: dict[str, Any],
+) -> dict[str, Any]:
+    """Run the playwright test browser in a larger resolution than its default."""
+    return {
+        **browser_context_args,
+        "viewport": {
+            "width": 1600,
+            "height": 900,
+        },
+    }
 
 
 @pytest.fixture(autouse=True)

--- a/tests/file_history/test_main.py
+++ b/tests/file_history/test_main.py
@@ -17,8 +17,8 @@ def upload_file(page: Page) -> None:
 
 
 def login(page: Page, api_key: str, x_system: str) -> None:
-    page.get_by_placeholder("API Key").fill(api_key)
-    page.get_by_placeholder("X-System").fill(x_system)
+    page.get_by_test_id("input-api-key").fill(api_key)
+    page.get_by_test_id("input-x-system").fill(x_system)
     page.get_by_test_id("login-button").click()
 
 
@@ -37,13 +37,13 @@ def test_upload(
     login(page, get_test_key("test"), "test")
     upload_file(page)
 
-    page.get_by_text("File History").click()
+    page.get_by_test_id("nav-item-/file-history").click()
     expect(page.get_by_text("test.csv")).to_be_visible()
     page.screenshot(path="tests_history_main_test_upload.png")
 
     # the file history is scoped to the x-system of the logged-in user
     logout(page)
     login(page, get_test_key("other"), "other")
-    page.get_by_text("File History").click()
+    page.get_by_test_id("nav-item-/file-history").click()
     expect(page.get_by_text("test.csv")).not_to_be_visible()
     page.screenshot(path="tests_history_main_test_upload_after_reload.png")

--- a/tests/login/test_main.py
+++ b/tests/login/test_main.py
@@ -11,8 +11,8 @@ def test_login_page(
     base_url: str,
 ) -> None:
     page.goto(base_url)
-    page.get_by_placeholder("X-System").fill("test")
-    page.get_by_placeholder("API Key").fill(get_test_key("test"))
+    page.get_by_test_id("input-x-system").fill("test")
+    page.get_by_test_id("input-api-key").fill(get_test_key("test"))
     page.screenshot(path="tests_test_login_test_login_page_filled.png")
 
     page.get_by_test_id("login-button").click()
@@ -32,8 +32,8 @@ def test_login_page_with_enter_key(
     base_url: str,
 ) -> None:
     page.goto(base_url)
-    page.get_by_placeholder("X-System").fill("test")
-    page.get_by_placeholder("API Key").fill(get_test_key("test"))
+    page.get_by_test_id("input-x-system").fill("test")
+    page.get_by_test_id("input-api-key").fill(get_test_key("test"))
     page.screenshot(path="tests_test_login_test_login_page_with_enter_key_filled.png")
 
     page.get_by_test_id("login-button").click()

--- a/tests/upload/test_main.py
+++ b/tests/upload/test_main.py
@@ -14,8 +14,8 @@ def upload_page(
     get_test_key: Callable[[str], str],
 ) -> Page:
     page.goto(base_url)
-    page.get_by_placeholder("API Key").fill(get_test_key("test"))
-    page.get_by_placeholder("X-System").fill("test")
+    page.get_by_test_id("input-api-key").fill(get_test_key("test"))
+    page.get_by_test_id("input-x-system").fill("test")
     page.get_by_test_id("login-button").click()
     return page
 


### PR DESCRIPTION
### Changes

- align `NavItem` with mex-admin: match on `router.route_id` via `route_ids`
  instead of comparing `router.page.path`, and track `active` instead of `underline`
- show a toast instead of a native browser alert on failed login
- add `data-testid` to the login inputs and nav bar links
- run the playwright test browser at 1600x900, like mex-admin

### Removed

- `html_lang` from the reflex app config
- background color of the nav bar spacer, leaving the backdrop filter

### Fixed

- focus the x-system input on the login page (`autofocus` was not a reflex prop)
- register `custom_backend_handler`, so backend errors surface as toasts
- pass the sitemap plugin class to `disable_plugins`, silencing a reflex 0.9 deprecation
- set `width: 100%` on the page container, matching mex-admin